### PR TITLE
Added: typography and global styles

### DIFF
--- a/src/Styles/GlobalStyle.ts
+++ b/src/Styles/GlobalStyle.ts
@@ -1,0 +1,38 @@
+import { createGlobalStyle } from "styled-components"
+
+const GlobalStyle = createGlobalStyle`
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+*, *::before, *:after {
+    -webkit-tap-highlight-color: transparent;
+}
+
+html {
+    font-family: 'Instrument Sans', sans-serif;
+}
+
+body {
+    width: 100vw;
+    min-height: 100vh;
+    background-color: #fafafa;
+    padding: 24px;
+}
+
+
+
+input,
+fieldset,
+button {
+    border: unset;
+    outline: unset;
+}
+
+
+`
+
+export { GlobalStyle }

--- a/src/Styles/Typography.ts
+++ b/src/Styles/Typography.ts
@@ -1,0 +1,33 @@
+import { css } from "styled-components"
+
+const commonStyles = css`
+  color: #333;
+  line-height: 150%;
+  font-style: normal;
+`
+
+const HeadingM = css`
+  ${commonStyles}
+  font-size: 32px;
+  font-weight: 700;
+`
+
+const HeadingS = css`
+  ${commonStyles}
+  font-size: 16px;
+  font-weight: 600;
+`
+
+const BodyM = css`
+  ${commonStyles}
+  font-size: 16px;
+  font-weight: 400;
+`
+
+const BodyS = css`
+  ${commonStyles}
+  font-size: 12px;
+  font-weight: 400;
+`
+
+export { HeadingM, HeadingS, BodyM, BodyS }

--- a/src/Styles/index.ts
+++ b/src/Styles/index.ts
@@ -1,0 +1,3 @@
+export { GlobalStyle } from "./GlobalStyle"
+export * as Typography from "./Typography"
+


### PR DESCRIPTION
### Description
In this pull request, I made changes to the following files:

1. Typography.ts:
   - Added styled-components CSS for common text styles such as `HeadingM`, `HeadingS`, `BodyM`, and `BodyS`. These styles define font sizes, font weights, and other common text properties to be used throughout the application.

2. GlobalStyles.ts:
   - Created a global CSS style using `createGlobalStyle` from styled-components. The global styles include resetting margins and paddings for all elements, setting the font family to 'Instrument Sans', and defining a default background color and padding for the body. Additionally, the CSS rule `-webkit-tap-highlight-color` is set to transparent to remove the tap highlight color on elements.

3. index.ts:
   - Exported the `GlobalStyle` component from the "GlobalStyle" file to make it accessible for use in other parts of the application.
   - Exported all the styles defined in "Typography.ts" using the `export * as` syntax, so that they can be easily imported and used in other components.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
